### PR TITLE
Add authentication system for Mink and future-Korp

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -9,3 +9,4 @@ auth_dir: "{{ app_dir }}/auth"
 mink_api_key: "{{ lookup('passwordstore', 'lb_passwords/mink/API_KEY')}}"
 
 mink_backend_socket_path: /run/mink-backend
+auth_socket_path: /run/oauth.sock

--- a/group_vars/all
+++ b/group_vars/all
@@ -5,5 +5,7 @@ data_root: /data
 mink_backend_dir: "{{ app_dir }}/mink-backend"
 mink_frontend_dir: "{{ app_dir }}/mink-frontend"
 sparv_dir: "{{ app_dir }}/sparv"
+auth_dir: "{{ app_dir }}/auth"
+mink_api_key: "{{ lookup('passwordstore', 'lb_passwords/mink/API_KEY')}}"
 
 mink_backend_socket_path: /run/mink-backend

--- a/mink-pouta.yml
+++ b/mink-pouta.yml
@@ -13,16 +13,22 @@
       community.general.timezone:
         name: "Europe/Helsinki"
         
-    - name: "Add clarin group"
+    - name: "Add gunicorn group"
       ansible.builtin.group:
-        name: clarin
+        name: gunicorn
         state: present
+
+    - name: "Add gunicorn user"
+      ansible.builtin.user:
+        name: gunicorn
+        state: present
+        generate_ssh_key: yes
+        group: gunicorn
 
     - name: "Ensure directories"
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
-        group: clarin
         mode: "u+rwx,g+rwxs,o+rx"
       loop:
         - "{{ data_root }}"
@@ -57,5 +63,7 @@
       tags: mink-backend
     - role: mink-frontend
       tags: mink-frontend
+    - role: auth
+      tags: auth
     # - role: firewall
     #   tags: firewall

--- a/roles/apache/templates/backend_proxy.conf.j2
+++ b/roles/apache/templates/backend_proxy.conf.j2
@@ -1,6 +1,6 @@
 # Configure reverse proxy for the Mink backend
 ProxyPreserveHost On
-ProxyPass "/mink/auth/" "unix:/run/mock-oauth.sock|http://auth.localhost/" retry=0
-ProxyPassReverse "/mink/auth/" "unix:/run/mock-oauth.sock|http://auth.localhost/"
+ProxyPass "/mink/auth/" "unix:/run/oauth.sock|http://auth.localhost/" retry=0
+ProxyPassReverse "/mink/auth/" "unix:/run/oauth.sock|http://auth.localhost/"
 ProxyPass "/mink/api/" "unix:/run/mink-backend|http://api.localhost/" retry=0
 ProxyPassReverse "/mink/api/" "unix:/run/mink-backend|http://api.localhost/"

--- a/roles/apache/templates/backend_proxy.conf.j2
+++ b/roles/apache/templates/backend_proxy.conf.j2
@@ -1,4 +1,6 @@
 # Configure reverse proxy for the Mink backend
 ProxyPreserveHost On
-ProxyPass "/mink/api/" "unix:{{ mink_backend_socket_path }}|http://127.0.0.1/" retry=0
-ProxyPassReverse "/mink/api/" "unix:{{ mink_backend_socket_path }}|http://127.0.0.1/"
+ProxyPass "/mink/auth/" "unix:/run/mock-oauth.sock|http://auth.localhost/" retry=0
+ProxyPassReverse "/mink/auth/" "unix:/run/mock-oauth.sock|http://auth.localhost/"
+ProxyPass "/mink/api/" "unix:/run/mink-backend|http://api.localhost/" retry=0
+ProxyPassReverse "/mink/api/" "unix:/run/mink-backend|http://api.localhost/"

--- a/roles/auth/handlers/main.yaml
+++ b/roles/auth/handlers/main.yaml
@@ -1,0 +1,10 @@
+---
+
+- name: restart systemd
+  command: systemctl daemon-reload
+
+- name: restart auth
+  systemd:
+    name: auth
+    state: restarted
+  become: yes

--- a/roles/auth/tasks/main.yaml
+++ b/roles/auth/tasks/main.yaml
@@ -1,12 +1,12 @@
 ---
 
-- name: "Ensure mock auth directory"
+- name: "Ensure auth directory"
   ansible.builtin.file:
     path: "{{ auth_dir }}"
     state: directory
     mode: "u+rwx,g+rwxs,o+rx"
       
-- name: "Install mock auth server"
+- name: "Install auth server"
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ auth_dir }}/{{ item.dest }}"
@@ -25,16 +25,16 @@
     dest: "{{ auth_dir }}/private_key.pem"
     mode: '0600'
       
-- name: Install mock oauth dependencies
+- name: Install oauth dependencies
   community.general.npm:
     path: "{{ auth_dir }}"
 
-- name: "Install mock auth server systemd script"
+- name: "Install auth server systemd script"
   ansible.builtin.template:
     src: auth.service
     dest: /etc/systemd/system/auth.service
 
-- name: Start mock auth server
+- name: Start auth server
   systemd:
     name: auth
     state: started

--- a/roles/auth/tasks/main.yaml
+++ b/roles/auth/tasks/main.yaml
@@ -1,0 +1,41 @@
+---
+
+- name: "Ensure mock auth directory"
+  ansible.builtin.file:
+    path: "{{ auth_dir }}"
+    state: directory
+    mode: "u+rwx,g+rwxs,o+rx"
+      
+- name: "Install mock auth server"
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ auth_dir }}/{{ item.dest }}"
+  loop:
+    - src: oauth_server.js.j2
+      dest: oauth_server.js
+    - src: package.json
+      dest: package.json
+    - src: auth_service_sqlite.js
+      dest: auth_service_sqlite.js
+  notify: restart auth
+
+- name: Write private key
+  copy:
+    content: "{{ lookup('passwordstore', 'auth_private_key') }}"
+    dest: "{{ auth_dir }}/private_key.pem"
+    mode: '0600'
+      
+- name: Install mock oauth dependencies
+  community.general.npm:
+    path: "{{ auth_dir }}"
+
+- name: "Install mock auth server systemd script"
+  ansible.builtin.template:
+    src: auth.service
+    dest: /etc/systemd/system/auth.service
+
+- name: Start mock auth server
+  systemd:
+    name: auth
+    state: started
+    enabled: yes

--- a/roles/auth/templates/auth.service
+++ b/roles/auth/templates/auth.service
@@ -1,0 +1,20 @@
+[Unit]
+Description= auth service for mink
+After=network.target
+
+[Service]
+Type=simple
+# Running as root for now
+User=root
+Group=root
+# another option for more restricted service is
+# DynamicUser=yes
+# see http://0pointer.net/blog/dynamic-users-with-systemd.html
+RuntimeDirectory=auth
+ExecStart=node oauth_server.js
+ExecReload=/bin/kill -s HUP $MAINPID
+TimeoutStopSec=5
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/auth/templates/auth_service_sqlite.js
+++ b/roles/auth/templates/auth_service_sqlite.js
@@ -1,0 +1,289 @@
+const sqlite = require('node:sqlite');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DB_PATH = '{{ auth_dir }}/resources.sqlite3';
+
+// Mock users database
+const demo_users = {
+    'demo@example.com': { password: 'password123'},
+    'tutkija@kielipankki.fi': { password: '123' },
+};
+
+
+// Permission levels
+const PERMISSIONS = {
+    READ: 1,
+    WRITE: 2,
+    ADMIN: 3
+};
+
+function create_db_if_missing() {
+    // Check if database file exists
+    if (fs.existsSync(DB_PATH)) {
+        return;
+    }
+
+    // Ensure directory exists
+    const dir = path.dirname(DB_PATH);
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Create database and tables
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        // Create USERS table
+        db.exec(`
+      CREATE TABLE USERS (
+        username TEXT PRIMARY KEY,
+        password TEXT NOT NULL
+      )
+    `);
+
+        // Create RESOURCES table
+        db.exec(`
+      CREATE TABLE RESOURCES (
+        resource_name TEXT PRIMARY KEY,
+        type TEXT NOT NULL CHECK (type IN ('corpus', 'metadata', 'other'))
+      )
+    `);
+
+        // Create GRANTS table with foreign key constraints
+        db.exec(`
+      CREATE TABLE GRANTS (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        resource_name TEXT NOT NULL,
+        permission_level INTEGER NOT NULL CHECK (permission_level IN (1, 2, 3)),
+        FOREIGN KEY (username) REFERENCES USERS(username) ON DELETE CASCADE,
+        FOREIGN KEY (resource_name) REFERENCES RESOURCES(resource_name) ON DELETE CASCADE,
+        UNIQUE(username, resource_name)
+      )
+    `);
+
+        // Enable foreign key constraints
+        db.exec('PRAGMA foreign_keys = ON');
+
+        // Init demo users
+        const stmt = db.prepare('INSERT INTO USERS (username, password) VALUES (?, ?)');
+        for (const demo_username in demo_users) {
+            stmt.run(demo_username, demo_users[demo_username].password);
+        }
+        
+    } finally {
+        db.close();
+    }
+}
+
+function get_user_password(username) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    try {
+        const stmt = db.prepare(`
+      SELECT password FROM USERS WHERE username = ?`);
+        return stmt.get(username).password;
+    } finally {
+        db.close()
+    }
+}
+
+function user_exists(username) {
+  const db = new sqlite.DatabaseSync(DB_PATH);
+  
+  try {
+    const stmt = db.prepare('SELECT 1 FROM USERS WHERE username = ? LIMIT 1');
+    const result = stmt.get(username);
+    return result !== undefined;
+  } finally {
+    db.close();
+  }
+}
+
+function get_user_scope(username) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare(`
+      SELECT r.resource_name, r.type, g.permission_level
+      FROM GRANTS g
+      JOIN RESOURCES r ON g.resource_name = r.resource_name
+      WHERE g.username = ?
+    `);
+        
+        const rows = stmt.all(username);
+        
+        const scope = {};
+        
+        for (const row of rows) {
+            const scopeKey = row.type === 'corpus' ? 'corpora' : row.type;
+            if (!scope[scopeKey]) {
+                scope[scopeKey] = {};
+            }
+            scope[scopeKey][row.resource_name] = row.permission_level;
+        }
+        
+        return scope;
+        
+    } finally {
+        db.close();
+    }
+}
+
+function get_user_scope_all_resources(username) {
+  const db = new sqlite.DatabaseSync(DB_PATH);
+  
+  try {
+    const stmt = db.prepare(`
+      SELECT r.resource_name, r.type, COALESCE(g.permission_level, 0) as permission_level
+      FROM RESOURCES r
+      LEFT JOIN GRANTS g ON r.resource_name = g.resource_name AND g.username = ?
+    `);
+    
+    const rows = stmt.all(username);
+    
+    const scope = {};
+    
+    for (const row of rows) {
+      const scopeKey = row.type === 'corpus' ? 'corpora' : row.type;
+      if (!scope[scopeKey]) {
+        scope[scopeKey] = {};
+      }
+      scope[scopeKey][row.resource_name] = row.permission_level;
+    }
+    
+    return { scope };
+    
+  } finally {
+    db.close();
+  }
+}
+
+class ResourceExistsError extends Error {
+    constructor(message, resourceName) {
+        super(message);
+        this.resourceName = resourceName;
+    }
+}
+
+function create_resource(resource_name, resource_type) {
+    if (!['corpus', 'metadata', 'other'].includes(resource_type)) {
+        throw new Error('Invalid resource type. Must be corpus, metadata, or other');
+    }
+    
+    const db = new sqlite.DatabaseSync(DB_PATH);
+
+    try {
+        // Check if resource already exists
+        const checkStmt = db.prepare('SELECT COUNT(*) as count FROM RESOURCES WHERE resource_name = ?');
+        const result = checkStmt.get(resource_name);
+        
+        if (result.count > 0) {
+            throw new ResourceExistsError(`Resource '${resource_name}' already exists`);
+        }
+        
+        const stmt = db.prepare('INSERT INTO RESOURCES (resource_name, type) VALUES (?, ?)');
+        stmt.run(resource_name, resource_type);
+    } finally {
+        db.close();
+    }
+}
+
+function delete_resource(resource_name) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare('DELETE FROM RESOURCES WHERE resource_name = ?');
+        stmt.run(resource_name);
+    } finally {
+        db.close();
+    }
+}
+
+function add_user(username) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare('INSERT INTO USERS (username) VALUES (?)');
+        stmt.run(username);
+    } finally {
+        db.close();
+    }
+}
+
+function delete_user(username) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare('DELETE FROM USERS WHERE username = ?');
+        stmt.run(username);
+        // Grants will be automatically deleted due to CASCADE constraint
+    } finally {
+        db.close();
+    }
+}
+
+function set_grant(user, resource_name, level) {
+    if (![1, 2, 3].includes(level)) {
+        throw new Error('Invalid permission level. Must be 1 (READ), 2 (WRITE), or 3 (ADMIN)');
+    }
+    
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare(`
+      INSERT INTO GRANTS (username, resource_name, permission_level) 
+      VALUES (?, ?, ?)
+      ON CONFLICT(username, resource_name) 
+      DO UPDATE SET permission_level = excluded.permission_level
+    `);
+        stmt.run(user, resource_name, level);
+    } finally {
+        db.close();
+    }
+}
+
+function remove_grant(user, resource_name) {
+    const db = new sqlite.DatabaseSync(DB_PATH);
+    
+    try {
+        const stmt = db.prepare('DELETE FROM GRANTS WHERE username = ? AND resource_name = ?');
+        stmt.run(user, resource_name);
+    } finally {
+        db.close();
+    }
+}
+
+function user_is_resource_admin(username, resourcename) {
+  const db = new sqlite.DatabaseSync(DB_PATH);
+  
+  try {
+    const stmt = db.prepare(`
+      SELECT 1 FROM GRANTS
+      WHERE username = ? AND resource_name = ? AND permission_level = 3
+      LIMIT 1
+    `);
+    const result = stmt.get(username, resourcename);
+    return result !== undefined;
+  } finally {
+    db.close();
+  }
+}
+
+module.exports = {
+    demo_users,
+    create_db_if_missing,
+    get_user_password,
+    user_exists,
+    get_user_scope,
+    get_user_scope_all_resources,
+    ResourceExistsError,
+    create_resource,
+    delete_resource,
+    add_user,
+    delete_user,
+    set_grant,
+    remove_grant,
+    user_is_resource_admin,
+    PERMISSIONS
+};

--- a/roles/auth/templates/oauth_server.js.j2
+++ b/roles/auth/templates/oauth_server.js.j2
@@ -1,0 +1,274 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const cors = require('cors');
+const path = require('path');
+const fs = require('fs');
+const cookieParser = require('cookie-parser');
+const sqlite = require('node:sqlite');
+const app = express();
+const SOCKET_PATH = process.env.SOCKET_PATH || '{{ auth_socket_path }}';
+
+// Secret for signing JWTs
+const JWT_SECRET = fs.readFileSync('{{ auth_dir }}/private_key.pem', 'utf8');
+const API_KEY = "{{ mink_api_key }}"
+
+const auth_cookie_name = 'kp-future-auth-token'
+
+const auth_db = require('./auth_service_sqlite.js');
+auth_db.create_db_if_missing();
+
+// In-memory token blacklist for logout functionality
+const blacklistedTokens = new Set();
+
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static('public'));
+app.use(cookieParser());
+
+// Serve login page
+app.get('/login', (req, res) => {
+  const { redirect, client_id, state, destination } = req.query;
+  
+  // Use destination if provided, otherwise fall back to redirect_uri
+    const finalRedirectUri = redirect; // destination || redirect;
+  
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>KP-future login</title>
+        <style>
+            body { font-family: Arial, sans-serif; max-width: 400px; margin: 100px auto; padding: 20px; }
+            .login-form { border: 1px solid #ddd; padding: 30px; border-radius: 8px; }
+            input { width: 100%; padding: 10px; margin: 10px 0; box-sizing: border-box; }
+            button { background: #007bff; color: white; padding: 12px 20px; border: none; border-radius: 4px; cursor: pointer; width: 100%; }
+            button:hover { background: #0056b3; }
+            .demo-users { margin-top: 20px; padding: 15px; background: #f8f9fa; border-radius: 4px; font-size: 12px; }
+        </style>
+    </head>
+    <body>
+        <div class="login-form">
+            <h2>KP-future login</h2>
+            <form action="auth" method="post">
+                <input type="hidden" name="redirect_uri" value="${finalRedirectUri || ''}" />
+                <input type="hidden" name="client_id" value="${client_id || ''}" />
+                <input type="hidden" name="state" value="${state || ''}" />
+                
+                <input type="email" name="username" placeholder="Email" required />
+                <input type="password" name="password" placeholder="Password" required />
+                <button type="submit">Login</button>
+            </form>
+            
+        </div>
+    </body>
+    </html>
+  `);
+});
+
+// Handle login form submission
+app.post('/auth', (req, res) => {
+  const { username, password, redirect_uri } = req.body;
+  
+    // Validate credentials
+    if (!auth_db.user_exists(username) || auth_db.get_user_password(username) !== password) {
+    return res.status(401).send(`
+      <h2>Login Failed</h2>
+      <p>Invalid credentials. <a href="login?redirect_uri=${redirect_uri}">Try again</a></p>
+    `);
+  }
+    
+    const authCode = jwt.sign({ username, timestamp: Date.now() }, JWT_SECRET, { expiresIn: '10m', algorithm: 'RS256' });
+    
+    res.cookie(auth_cookie_name,
+               authCode, { httpOnly: false,
+                           secure: true,     // HTTPS must be enabled
+                           sameSite: 'lax',  // CSRF protection
+                           maxAge: 3600000,  // 1 hour in milliseconds
+                           path: '/'         // Available on all paths
+                         });
+    
+    if (redirect_uri) {
+        res.redirect(redirect_uri);
+    }  else {
+        // Or show some error instead?
+        res.json({ code: authCode });
+    }
+});
+
+app.get('/jwt', (req, res) => {
+    const sessionToken = req.cookies[auth_cookie_name];
+    
+    if (!sessionToken) {
+        return res.status(401).json({ error: 'unauthorized' });
+    }
+
+    if (blacklistedTokens.has(sessionToken)) {
+        return res.status(401).json({ error: 'token_revoked' });
+    }
+
+    try {
+        const decoded = jwt.verify(sessionToken, JWT_SECRET);
+        const username = decoded.username;
+        // If the auth cookie was good, renew it
+        const authCode = jwt.sign({ username, timestamp: Date.now() }, JWT_SECRET, { expiresIn: '10m', algorithm: 'RS256' });
+        res.cookie(auth_cookie_name,
+                   authCode, { httpOnly: false,
+                               secure: true,
+                               sameSite: 'lax',
+                               maxAge: 3600000,
+                               path: '/'
+                             });
+        // Create and return JWT
+        const token = jwt.sign(
+            {
+                email: username,
+                name: username, // We could get these from the db, but let's wait for kp-aai
+                exp: Math.floor(Date.now() / 1000) + 3600,
+                scope: auth_db.get_user_scope(username),
+                levels: auth_db.PERMISSIONS,
+                sub: username,
+                idp: "kp-future-auth"
+            },
+            JWT_SECRET,
+            {algorithm: 'RS256'});
+        res.send(token);
+
+    } catch (error) {
+        // Token invalid/expired, clear the cookie
+        res.clearCookie(auth_cookie_name);
+        res.status(401).json({ error: 'unauthorized' });
+    }
+});
+
+// The /resource endpoint used by Mink for creating
+app.post('/resource/:resourcename', (req, res) => {
+    const authCode = req.body.jwt;
+    if (!authCode) {
+        return res.status(401).json({ error: 'unauthorized' });
+    }
+    
+    try {
+        const decoded = jwt.verify(authCode, JWT_SECRET);
+        const username = decoded.email;
+        const resourcename = req.params.resourcename;
+        auth_db.create_resource(resourcename, "corpus");
+        auth_db.set_grant(username, resourcename, auth_db.PERMISSIONS.ADMIN);
+        res.status(201).send(resourcename);
+    } catch (error) {
+        if (error instanceof auth_db.ResourceExistsError) {
+            return res.status(400).json({ error: 'resource already exists'});
+        } else {
+            // TODO we could handle more possibilities
+            console.log("Returning 401 due to invalid auth token")
+            return res.status(401).json({ error: 'invalid auth token' });
+        }
+    }
+});
+
+// Deleting a resource
+app.delete('/resource/:resourcename', (req, res) => {
+    const authHeader = req.headers.authorization;
+    const resourcename = req.params.resourcename;
+
+    if (authHeader !== "apikey " + API_KEY) {
+        return res.status(401).json({ error: 'unauthorized' });
+    }
+    auth_db.delete_resource(resourcename);
+    // Even if it didn't exist we're happy
+    return res.status(204).send(resourcename);
+});
+
+app.get('/logout', (req, res) => {
+    const redirect_uri = req.query.redirect_uri
+    const sessionToken = req.cookies[auth_cookie_name];
+    if (sessionToken) {
+        // Clean up old tokens (TODO: use eg. Redis with TTL)
+        if (blacklistedTokens.size > 1000) {
+            // TODO: only clean up expired tokens
+            blacklistedTokens.clear();
+        }
+        // Add token to blacklist
+        blacklistedTokens.add(sessionToken);
+    }
+    
+    if (redirect_uri) {
+        res.redirect(redirect_uri);
+  } else {
+      res.json({ message: 'Logged out successfully' });
+  }
+});
+
+// Health check / discovery endpoint - for later
+// app.get('/.well-known/openid_configuration', (req, res) => {
+//   // For Unix socket, you'll need to configure your reverse proxy/web server
+//   // to provide the external base URL. For now, using a placeholder.
+//   const baseUrl = process.env.BASE_URL || 'http://localhost';
+//   res.json({
+//     issuer: baseUrl,
+//     authorization_endpoint: `${baseUrl}/login`,
+//     token_endpoint: `${baseUrl}/token`,
+//     userinfo_endpoint: `${baseUrl}/userinfo`,
+//     end_session_endpoint: `${baseUrl}/logout`,
+//     jwks_uri: `${baseUrl}/jwks`,
+//     response_types_supported: ['code'],
+//     grant_types_supported: ['authorization_code'],
+//     subject_types_supported: ['public']
+//   });
+// });
+
+// JWKS endpoint (simplified - for token verification)
+// app.get('/jwks', (req, res) => {
+//   res.json({
+//     keys: [
+//       {
+//         kty: 'oct',
+//         use: 'sig',
+//         alg: 'HS256',
+//         k: Buffer.from(JWT_SECRET).toString('base64url')
+//       }
+//     ]
+//   });
+// });
+
+// Clean up existing socket file if it exists
+if (fs.existsSync(SOCKET_PATH)) {
+  fs.unlinkSync(SOCKET_PATH);
+}
+
+app.listen(SOCKET_PATH, () => {
+  console.log(`Mink OAuth2 Server listening on Unix socket: ${SOCKET_PATH}`);
+  console.log(`You need configure a reverse proxy (nginx, Apache, etc.) to serve this.`);
+  console.log('\nDemo users:');
+    Object.keys(auth_db.demo_users).forEach(email => {
+        console.log(`  ${email} / ${auth_db.demo_users[email].password}`);
+    });
+  
+  // Set socket permissions (optional - adjust as needed)
+  try {
+    fs.chmodSync(SOCKET_PATH, '666'); // rw-rw-rw-
+  } catch (err) {
+    console.warn('Could not set socket permissions:', err.message);
+  }
+});
+
+// Graceful shutdown - clean up socket file
+process.on('SIGINT', () => {
+  console.log('\nShutting down gracefully...');
+  if (fs.existsSync(SOCKET_PATH)) {
+    fs.unlinkSync(SOCKET_PATH);
+  }
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.log('\nReceived SIGTERM, shutting down gracefully...');
+  if (fs.existsSync(SOCKET_PATH)) {
+    fs.unlinkSync(SOCKET_PATH);
+  }
+  process.exit(0);
+});
+
+
+
+module.exports = app;

--- a/roles/auth/templates/oauth_server.js.j2
+++ b/roles/auth/templates/oauth_server.js.j2
@@ -26,12 +26,14 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.static('public'));
 app.use(cookieParser());
 
+const fallback_redirect_uri = 'https://www.kielipankki.fi'
+
 // Serve login page
 app.get('/login', (req, res) => {
   const { redirect, client_id, state, destination } = req.query;
   
   // Use destination if provided, otherwise fall back to redirect_uri
-    const finalRedirectUri = redirect; // destination || redirect;
+    const finalRedirectUri = redirect || fallback_redirect_uri;
   
   res.send(`
     <!DOCTYPE html>

--- a/roles/auth/templates/package.json
+++ b/roles/auth/templates/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "oauth-server",
+  "version": "1.0.0",
+  "description": "Simple OAuth2/OIDC server for mink",
+  "main": "oauth_server.js",
+  "scripts": {
+    "start": "node oauth_server.js",
+    "dev": "nodemon oauth_server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "cors": "^2.8.5",
+      "cookie-parser": "^1.4.6"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}


### PR DESCRIPTION
Some features of sb-auth need to be emulated locally, and this is now done with a node.js implementation of OAuth included in the auth role here.

It exposes

- `GET /login` - a simple login page is rendered, it expects a `redirect` url parameter for returning to the app.
- `POST /auth` - the login page submits a form with username, password and redirect here. It sets a cookie with the name in `auth_cookie_name`, containing a `username`, timestamp and expiration time, and signs it with the private key from `JWT_SECRET`. Then the user is redirected.
- `GET /jwt` - the auth cookie from `/auth` is checked for signature and non-expiration. If those are ok, the auth cookie is renewed, and a signed jwt token with user information and scope (corpus rights) is returned. Otherwise return 401 (unauthorized), which the app should know means the user needs to sign in.
- `POST /resource/resourcename` - (attempt to) create a resource, returning 201 for success, 400 for already exists, and 401 for authorization needed. The auth cookie is checked.
- `DELETE /resource/resourcename` - delete a resource. The only thing checked is the API key. Not sure why nothing else. The API key should be known only to the Mink backend, not the user, so I assume https is enough to keep it secure.

There's also a commented-out discovery and JWKS endpoint for possible future use.

The app makes its own socket, a web server needs to be configured to point there (here, Apache).

There's a systemd service for handling the auth process.

A sqlite3 database is used to recording user and corpus information. Passwords not hashed or salted at this time.

TODO: handle logout a bit better. Now tokens are blacklisted into a in-process-memory set, and evicted all at once when there are over a thousand. Better: put them in eg. redis and evict them only when they expire.