### PR TITLE
WIP KP-10720 Add "sparv" user

### DIFF
--- a/inventories/dev/key_installing_targets
+++ b/inventories/dev/key_installing_targets
@@ -1,0 +1,7 @@
+[korp]
+195.148.21.52 # future
+
+[korp:vars]
+ansible_user=almalinux
+mink_korp_public_key_path=/home/mink/.ssh/id_rsa.pub
+

--- a/mink-pouta.yml
+++ b/mink-pouta.yml
@@ -25,6 +25,13 @@
         generate_ssh_key: yes
         group: gunicorn
 
+    - name: "Add sparv user"
+      ansible.builtin.user:
+        name: sparv
+        state: present
+        generate_ssh_key: yes
+        group: gunicorn
+
     - name: "Ensure directories"
       ansible.builtin.file:
         path: "{{ item }}"

--- a/mink-pouta.yml
+++ b/mink-pouta.yml
@@ -32,6 +32,21 @@
         generate_ssh_key: yes
         group: gunicorn
 
+    - name: "Collect sparv user's public key"
+      ansible.core.slurp:
+        src: /home/sparv/ssh/id_rsa.pub
+      register: sparv_ssh_pub
+
+    - name: "Install sparv user's key in Korp"
+      authorized_key:
+        user: mink
+        key: "{{ sparv_ssh_pub.content | b64decode }}"
+        state: present
+      delegate_to:
+        "{{ item }}"
+      loop: "{{ groups['korp'] | default([]) }}"
+      when: groups['korp'] is defined and groups['korp'] | length > 0
+
     - name: "Ensure directories"
       ansible.builtin.file:
         path: "{{ item }}"

--- a/roles/mink-backend/templates/config.py.j2
+++ b/roles/mink-backend/templates/config.py.j2
@@ -1,7 +1,7 @@
-# Obviously not how we want to do this forever..
-SSH_KEY = "~/.ssh/localroot_id_rsa"
+# The private key corresponding to the public key installed on the Korp host
+SSH_KEY = "~/.ssh/mink_korp_id_rsa"
 SPARV_HOST = "localhost"
-SPARV_USER = "root"
+SPARV_USER = "sparv"
 
 # Sparv's 'run' command. The default includes "--socket ~/sparv-pipeline/sparv.socket"
 # but that will only work if there's eg.
@@ -17,8 +17,8 @@ MEMCACHED_SOCKET = "memcached.sock"
 MINK_SECRET_KEY = "{{ lookup('passwordstore', 'lb_passwords/mink/MINK_SECRET_KEY')}}"
 SBAUTH_API_KEY = "{{ mink_api_key }}"
 SBAUTH_PUBKEY_FILE = "keys/public_key.pem"
-SBAUTH_URL = "https://www.kielipankki.fi/future/mink/auth/resource/"
-MINK_URL = "https://www.kielipankki.fi/future/mink/api"
+SBAUTH_URL = "/auth/resource/"
+MINK_URL = "/future/mink/api"
 SPARV_DEFAULT_STRIX_INSTALLS = []  # No strix targets please
 SPARV_DEFAULT_STRIX_UNINSTALLS = []
 SPARV_DEFAULT_EXPORTS = [

--- a/roles/mink-frontend/templates/env.local
+++ b/roles/mink-frontend/templates/env.local
@@ -11,11 +11,11 @@ VITE_BACKEND_URL=https://www.kielipankki.fi/future/mink/api
 # DEV_HTTPS_CERT=../spraakbanken.gu.se+1.pem
 
 # Url to SB-Auth
-VITE_AUTH_URL=https://www.kielipankki.fi/future/mink/auth/
+VITE_AUTH_URL=/secure/auth/
 # Url to SB-Auth-JWT (defaults to VITE_AUTH_URL + "jwt")
-VITE_JWT_URL=https://www.kielipankki.fi/future/mink/auth/jwt/
+VITE_JWT_URL=/api/auth/jwt
 # SB-Auth logout url
-VITE_LOGOUT_URL=https://www.kielipankki.fi/future/mink/auth/logout?redirect_uri=https%3A%2F%2Fwww.kielipankki.fi%2Ffuture%2Fmink
+VITE_LOGOUT_URL=/secure/auth/logout?redirect_uri=https%3A%2F%2Fwww.kielipankki.fi%2Ffuture%2Fmink
 #https://sp.spraakbanken.gu.se/Shibboleth.sso/Logout
 
 # Url to Korp frontend


### PR DESCRIPTION
The sparv user will run sparv and own the ssh key for connecting to Korp for installing corpora.

This also updates the auth paths to what we now have in proxy, instead of the old Mink-co-hosted auth (oops).