### PR TITLE
KP 11570-related fixes

### DIFF
--- a/roles/apache/tasks/main.yaml
+++ b/roles/apache/tasks/main.yaml
@@ -23,3 +23,16 @@
       dest: /etc/httpd/conf.d/backend_proxy.conf
     - src: frontend_routes.conf
       dest: /etc/httpd/conf.d/frontend_routes.conf
+    - src: access_log.conf.j2
+      dest: /etc/httpd/conf.d/access_log.conf
+
+# Disable the package-default CustomLog so the one in conf.d/access_log.conf
+# (which honors the "dontlog" env var) is the only access logger. Matches the
+# active line shipped by httpd; the commented "common" variant above it is
+# left alone. Idempotent: re-runs no-op once the line is commented out.
+- name: "Disable default CustomLog in httpd.conf"
+  ansible.builtin.replace:
+    path: /etc/httpd/conf/httpd.conf
+    regexp: '^(\s*)CustomLog "logs/access_log" combined\s*$'
+    replace: '\1#CustomLog "logs/access_log" combined  # disabled by mink ansible; see conf.d/access_log.conf'
+  notify: restart httpd

--- a/roles/apache/templates/access_log.conf.j2
+++ b/roles/apache/templates/access_log.conf.j2
@@ -1,0 +1,8 @@
+# Re-defines the package-default access log so it can honor "dontlog".
+# The default CustomLog in /etc/httpd/conf/httpd.conf is commented out by
+# the role's tasks; do not re-enable it without disabling this one.
+
+# Add SetEnvIf rules here for any route we want kept out of access_log.
+SetEnvIf Request_URI "/mink/api/advance-queue$" dontlog
+
+CustomLog "logs/access_log" combined env=!dontlog

--- a/roles/mink-backend/templates/config.py.j2
+++ b/roles/mink-backend/templates/config.py.j2
@@ -17,6 +17,9 @@ SBAUTH_API_KEY = "{{ mink_api_key }}"
 SBAUTH_PUBKEY_FILE = "keys/public_key.pem"
 SBAUTH_URL = "https://www.kielipankki.fi/api/auth/resource/"
 MINK_URL = "https://www.kielipankki.fi/future/mink/api"
+# queue_manager.py uses this to call /advance-queue locally via Apache's
+# global ProxyPass to the unix socket, avoiding the public proxy hop.
+MINK_INTERNAL_URL = "http://127.0.0.1/mink/api"
 
 # Korp and CWB configuration
 KORP_CONFIG_DIR = "/v/corpora/config"

--- a/roles/sparv/tasks/main.yaml
+++ b/roles/sparv/tasks/main.yaml
@@ -70,8 +70,8 @@
   ansible.builtin.shell: |
     tmpdir=$(mktemp -d)
     curl -L -o "$tmpdir/treetagger.tar.gz" {{ treetagger_url }}
-    tar -xzf "$tmpdir/treetagger.tar.gz" -C "$tmpdir" tree-tagger-{{ treetagger_version }}/bin/tree-tagger
-    install -m 0755 "$tmpdir/tree-tagger-{{ treetagger_version }}/bin/tree-tagger" {{ sparv_datadir }}/bin/tree-tagger
+    tar -xzf "$tmpdir/treetagger.tar.gz" -C "$tmpdir" bin/tree-tagger
+    install -m 0755 "$tmpdir/bin/tree-tagger" {{ sparv_datadir }}/bin/tree-tagger
     rm -rf "$tmpdir"
   args:
     creates: "{{ sparv_datadir }}/bin/tree-tagger"


### PR DESCRIPTION
- MINK_INTERNAL_URL and ignore Apache lines: this has to do with routing the advance-queue calls locally, rather than all the way around the proxy
- TreeTagger: the installation role was probably originally broken, and only my manual installation was working for a while.