### PR TITLE
KP-11200 Pin Mink->Korp SSH keys to source IP

### DIFF
--- a/inventories/dev/hosts
+++ b/inventories/dev/hosts
@@ -1,6 +1,17 @@
 all:
   vars:
     external_ip: 195.148.30.10
+    # Source IP the Korp host sees when the Mink machine connects over SSH. Used to
+    # lock the sparv->mink@korp key to this origin via from="..." in authorized_keys,
+    # so a leaked key is useless from anywhere else. Set this PER INVENTORY to the
+    # address as Korp sees it (post-NAT); there is no safe universal default:
+    #   - same Pouta project as Korp (e.g. future Korp) -> Mink's INTERNAL/fixed IP
+    #   - production (non-Pouta) or cross-project Pouta  -> Mink's EXTERNAL/floating IP
+    # May be a comma-separated list or CIDR. Verify with:
+    #   ssh mink@<korp-host> 'echo $SSH_CONNECTION'   # first field is the source IP
+    # Dev has no korp group so this is never consumed here; it defaults to the
+    # external IP only as an example of the production/cross-network case.
+    mink_source_ip: "{{ external_ip }}"
     koivu_retention_months: 1
     protected_host: false
   hosts:

--- a/playbooks/mink-pouta.yml
+++ b/playbooks/mink-pouta.yml
@@ -45,12 +45,29 @@
       ansible.builtin.authorized_key:
         user: sparv
         key: "{{ gunicorn_ssh_pub.content | b64decode }}"
+        # This hop is always loopback (SPARV_HOST=localhost), so pin it there.
+        key_options: 'from="127.0.0.1,::1"'
         state: present
+
+    - name: "Require a pinned source IP before installing the Korp key"
+      ansible.builtin.assert:
+        that:
+          - mink_source_ip is defined
+          - mink_source_ip | string | length > 0
+        fail_msg: >-
+          mink_source_ip must be set (in this inventory) to the address the Korp host
+          sees when Mink connects, so the sparv->mink@korp key can be locked to it.
+          Use Mink's internal IP if it shares a Pouta project with Korp, otherwise its
+          external/floating IP. See inventories/*/hosts.
+      when: groups['korp'] is defined and groups['korp'] | length > 0
 
     - name: "Install sparv user's key in Korp"
       ansible.builtin.authorized_key:
         user: mink
         key: "{{ sparv_ssh_pub.content | b64decode }}"
+        # Lock this key to the Mink machine's source IP so a leaked key cannot be
+        # used from anywhere else. mink_source_ip is set per inventory.
+        key_options: 'from="{{ mink_source_ip }}"'
         state: present
       delegate_to:
         "{{ item }}"


### PR DESCRIPTION
Lock the sparv->mink@korp authorized_key to the Mink machine's source IP (from="..."), and the gunicorn->sparv@localhost key to loopback, so an exfiltrated key is unusable from anywhere else. mink_source_ip is set per inventory (internal IP when Mink shares a Pouta project with Korp, otherwise external/floating IP); an assertion blocks installing the Korp key if it is unset, so the key is never installed without a deliberate source-IP pin.