### PR TITLE
Kp 11698 trankit token name orphan fix

### DIFF
--- a/roles/sparv/templates/config_default.yaml
+++ b/roles/sparv/templates/config_default.yaml
@@ -13,7 +13,12 @@ korp:
   remote_host: "mink@{{ groups['korp'][0] }}"
   config_dir: "{{ korp_config_dir }}"
   annotation_definitions:
-    <token>:trankit.deprel: deprel_trankit
+    # trankit attrs only exist for trankit languages, which all bind <token> to
+    # trankit.token, so these are correct for eng/fin/swe and inert elsewhere.
+    # There might be a better way to smuggle these in, but I will revisit that..
+    trankit.token:trankit.deprel: deprel_trankit
+    trankit.token:trankit.ne_type: ne_type_conll
+    trankit.token:trankit.ne_part: ner_bioes
 
 cwb:
   remote_host: "mink@{{ groups['korp'][0] }}"


### PR DESCRIPTION
Two things needed to be adjusted here: using `trankit.token` (from trankit tokenisation) rather than `<token>` for attaching dependencies, and translating `trankit.ne_type` and `trankit.ner_bioes`, to equivalent files defined in https://github.com/CSCfi/Kielipankki-korp-corpus-config/tree/future/attributes/positional, which are not really exclusively a trankit concept, so should not be named after it. Another option would maybe be to try to get them more into "core" Mink, so they would not be special to trankit on that side either, but for now this is a kind of simple solution.